### PR TITLE
Add option to use direct spotify and audio link

### DIFF
--- a/_web/_includes/search-js.html
+++ b/_web/_includes/search-js.html
@@ -77,6 +77,17 @@ function getTitle(title, artist, url) {
     return title;
 }
 
+function goDirect() {
+    var spotify = $("#direct-spotify").val();
+    var match = spotify.match(/spotify.com\/track\/([^/?]+)/);
+    if (match === null) {
+        alert("Please enter a valid Spotify song share link (open.spotify.com/track/<id>)");
+        return;
+    }
+    var params = new URLSearchParams({id: match[1], audio: $("#direct-audio").val()});
+    window.location.href = "{% if page.app == 'jukebox' %}jukebox{% elsif page.app == 'canonizer' %}canonizer{% endif %}_go.html?" + params.toString();
+}
+
 function init() {
     $("#go-search").click(function () {
         searchForTrack();
@@ -86,6 +97,10 @@ function init() {
         if (e.keyCode == 13) {
             searchForTrack();
         }
+    });
+
+    $("#go-direct").click(function () {
+        goDirect();
     });
 
     $.getJSON('api/site/popular/{% if page.app == 'jukebox' %}jukebox{% elsif page.app == 'canonizer' %}canonizer{% endif %}', {count: 12}, function (data) {

--- a/_web/_layouts/search.html
+++ b/_web/_layouts/search.html
@@ -6,18 +6,14 @@ layout: default
   <div class="container">
     <h2> Search for a song</h2>
         <div id='select-track'>
-          <div id="search-div">
-            <div id='search-form'>
-                Search for a track: <input id="search" type="text" class="input-large search-query" title="search">
-                <button id="go-search" class='btn btn-default'> Search </button>
-            </div>
-          </div>
+          <p><label>Search for a track: <input id="search" type="text" class="input-large search-query" title="search"></label></p>
+          <p><button id="go-search" class='btn btn-sm btn-default'> Search </button></p>
         </div>
     <h2> Use direct Spotify + audio link</h2>
         <div id='direct-links'>
           <p><label>Spotify link: <input id="direct-spotify" type="text" class="input-large"></label></p>
           <p><label>Audio link (e.g. Youtube): <input id="direct-audio" type="text" class="input-large"></label></p>
-          <p><button id="go-direct" class='btn btn-default'> Open </button></p>
+          <p><button id="go-direct" class='btn btn-sm btn-default'> Open </button></p>
         </div>
     <h2 id="pick"> Or pick one of these favorites</h2>
         <div id="song-list"> </div>

--- a/_web/_layouts/search.html
+++ b/_web/_layouts/search.html
@@ -13,6 +13,12 @@ layout: default
             </div>
           </div>
         </div>
+    <h2> Use direct Spotify + audio link</h2>
+        <div id='direct-links'>
+          <p><label>Spotify link: <input id="direct-spotify" type="text" class="input-large"></label></p>
+          <p><label>Audio link (e.g. Youtube): <input id="direct-audio" type="text" class="input-large"></label></p>
+          <p><button id="go-direct" class='btn btn-default'> Open </button></p>
+        </div>
     <h2 id="pick"> Or pick one of these favorites</h2>
         <div id="song-list"> </div>
         </div>


### PR DESCRIPTION
It is annoying when you wait in the queue only to get the wrong song audio, which you can fix in the tune settings, and then have to wait again. Therefore here's an improvement where you can set the audio url directly from the search page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/undermybrella/eternaljukebox/167)
<!-- Reviewable:end -->
