### PR TITLE
Fix exceptions in coroutines timing out Vert.x handler

### DIFF
--- a/src/main/kotlin/org/abimon/eternalJukebox/CoroutineUtils.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/CoroutineUtils.kt
@@ -1,6 +1,7 @@
 package org.abimon.eternalJukebox
 
 import kotlinx.coroutines.CoroutineExceptionHandler
+import org.slf4j.Logger
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 
@@ -16,3 +17,9 @@ public inline fun NamedCoroutineExceptionHandler(name: String, crossinline handl
 
         override fun toString(): String = name
     }
+
+data class LogCoroutineExceptionHandler(val logger: Logger) : AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler {
+    override fun handleException(context: CoroutineContext, exception: Throwable) {
+        logger.error("[$context] An unhandled exception occurred", exception)
+    }
+}

--- a/src/main/kotlin/org/abimon/eternalJukebox/CoroutineUtils.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/CoroutineUtils.kt
@@ -1,0 +1,18 @@
+package org.abimon.eternalJukebox
+
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Creates a named [CoroutineExceptionHandler] instance.
+ * @param handler a function which handles exception thrown by a coroutine
+ */
+@Suppress("FunctionName")
+public inline fun NamedCoroutineExceptionHandler(name: String, crossinline handler: (CoroutineContext, Throwable) -> Unit): CoroutineExceptionHandler =
+    object : AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler {
+        override fun handleException(context: CoroutineContext, exception: Throwable) =
+            handler.invoke(context, exception)
+
+        override fun toString(): String = name
+    }

--- a/src/main/kotlin/org/abimon/eternalJukebox/EternalJukebox.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/EternalJukebox.kt
@@ -13,6 +13,7 @@ import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpServer
 import io.vertx.ext.web.Router
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -42,7 +43,10 @@ import java.util.concurrent.TimeUnit
 import kotlin.reflect.jvm.jvmName
 
 object EternalJukebox : CoroutineScope {
-    override val coroutineContext = SupervisorJob() + CoroutineName("EternalJukebox") // `SupervisorJob` means this won't be cancelled
+    // `SupervisorJob` means this won't be canceled
+    override val coroutineContext = SupervisorJob() + CoroutineName("EternalJukebox") + NamedCoroutineExceptionHandler("LogExceptionHandler") { ctx, exception ->
+        logger.error("[$ctx] An unhandled exception occurred", exception)
+    }
 
     val jsonMapper: ObjectMapper = ObjectMapper()
             .registerModules(Jdk8Module(), KotlinModule.Builder().build(), JavaTimeModule(), ParameterNamesModule())

--- a/src/main/kotlin/org/abimon/eternalJukebox/EternalJukebox.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/EternalJukebox.kt
@@ -13,7 +13,6 @@ import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpServer
 import io.vertx.ext.web.Router
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -43,10 +42,10 @@ import java.util.concurrent.TimeUnit
 import kotlin.reflect.jvm.jvmName
 
 object EternalJukebox : CoroutineScope {
+    private val logger: Logger = LoggerFactory.getLogger("EternalBox")
+
     // `SupervisorJob` means this won't be canceled
-    override val coroutineContext = SupervisorJob() + CoroutineName("EternalJukebox") + NamedCoroutineExceptionHandler("LogExceptionHandler") { ctx, exception ->
-        logger.error("[$ctx] An unhandled exception occurred", exception)
-    }
+    override val coroutineContext = SupervisorJob() + CoroutineName("EternalJukebox") + LogCoroutineExceptionHandler(logger)
 
     val jsonMapper: ObjectMapper = ObjectMapper()
             .registerModules(Jdk8Module(), KotlinModule.Builder().build(), JavaTimeModule(), ParameterNamesModule())
@@ -79,8 +78,6 @@ object EternalJukebox : CoroutineScope {
     val analyticsProviders: List<IAnalyticsProvider>
 
     val database: IDatabase
-
-    private val logger: Logger = LoggerFactory.getLogger("EternalBox")
 
     private val schedule: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
     private val apis = ArrayList<IAPI>()

--- a/src/main/kotlin/org/abimon/eternalJukebox/VertxExtensions.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/VertxExtensions.kt
@@ -7,9 +7,12 @@ import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
 import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.launch
 import org.abimon.eternalJukebox.objects.ClientInfo
 import org.abimon.eternalJukebox.objects.ConstantValues
+import org.abimon.eternalJukebox.objects.CoroutineClientInfo
+import org.slf4j.LoggerFactory
 
 fun HttpServerResponse.end(json: JsonArray) = putHeader("Content-Type", "application/json").end(json.toString())
 fun HttpServerResponse.end(json: JsonObject) = putHeader("Content-Type", "application/json").end(json.toString())
@@ -32,6 +35,7 @@ val RoutingContext.clientInfo: ClientInfo
             return data()[ConstantValues.CLIENT_INFO] as ClientInfo
 
         val info = ClientInfo(this)
+        response().putHeader("X-Client-UID", info.userUID)
 
         data()[ConstantValues.CLIENT_INFO] = info
 
@@ -44,9 +48,17 @@ fun Route.suspendingBodyHandler(handler: suspend (RoutingContext) -> Unit, maxMb
     handler(BodyHandler.create().setBodyLimit(maxMb * 1000 * 1000).setDeleteUploadedFilesOnEnd(true))
         .suspendingHandler(handler)
 
+val SUSPENDING_HANDLER_LOGGER = LoggerFactory.getLogger("SuspendingHandler")
+
 fun Route.suspendingHandler(handler: suspend (RoutingContext) -> Unit): Route =
     handler { ctx ->
-        EternalJukebox.launch(ctx.vertx().dispatcher()) {
-            handler(ctx)
+        EternalJukebox.launch(ctx.vertx().dispatcher() + CoroutineClientInfo(ctx)) {
+            try {
+                handler(ctx)
+            } catch (th: Throwable) {
+                ctx.fail(th)
+
+                SUSPENDING_HANDLER_LOGGER.error("[{}] An exception occurred whilst handling a request", coroutineContext, th)
+            }
         }
     }

--- a/src/main/kotlin/org/abimon/eternalJukebox/VertxExtensions.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/VertxExtensions.kt
@@ -7,7 +7,6 @@ import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
 import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.kotlin.coroutines.dispatcher
-import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.launch
 import org.abimon.eternalJukebox.objects.ClientInfo
 import org.abimon.eternalJukebox.objects.ConstantValues

--- a/src/main/kotlin/org/abimon/eternalJukebox/objects/CoroutineClientInfo.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/objects/CoroutineClientInfo.kt
@@ -1,0 +1,13 @@
+package org.abimon.eternalJukebox.objects
+
+import io.vertx.ext.web.RoutingContext
+import org.abimon.eternalJukebox.clientInfo
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+data class CoroutineClientInfo(val userUID: String, val path: String) :
+    AbstractCoroutineContextElement(CoroutineClientInfo) {
+    constructor(ctx: RoutingContext) : this(ctx.clientInfo.userUID, ctx.normalisedPath())
+
+    public companion object Key : CoroutineContext.Key<CoroutineClientInfo>
+}

--- a/src/main/kotlin/org/abimon/eternalJukebox/objects/YoutubeVideos.kt
+++ b/src/main/kotlin/org/abimon/eternalJukebox/objects/YoutubeVideos.kt
@@ -19,7 +19,7 @@ data class YoutubePageInfo(
 
 data class YoutubeID(
         val kind: String,
-        val videoId: String
+        val videoId: String? = null
 )
 
 data class YoutubeVideoThumbnail(


### PR DESCRIPTION
Currently, if an uncaught exception is thrown in a vert.x coroutine handler, the handler will sit endlessly waiting for either end to close the connection. 

This PR fixes that, while also logging exceptions that fall through better, and also fixing the error that brought this up - YouTube sometimes erroneously returns non-video results when we search for only videos, crashing the deserialisation.

This PR fixes [#BOX-14](https://youtrack.eternalbox.dev/issue/BOX-14).